### PR TITLE
Fix typos in section and section-list constructors

### DIFF
--- a/lib/client/section-list.js
+++ b/lib/client/section-list.js
@@ -15,7 +15,7 @@ function SectionList() {
 }
 
 SectionList.prototype = {
-    constuctor: SectionList,
+    constructor: SectionList,
 
     expandAll: function() {
         this._sections.forEach(function(section) {

--- a/lib/client/section.js
+++ b/lib/client/section.js
@@ -41,7 +41,7 @@ function Section(node) {
 }
 
 Section.prototype = {
-    constuctor: Section,
+    constructor: Section,
     expand:function() {
         this.domNode.classList.remove('section_collapsed');
     },


### PR DESCRIPTION
This changes should fix error ```Uncaught SyntaxError: Unexpected token u```.
